### PR TITLE
Proposed fix to CW ID stutter.

### DIFF
--- a/beacon/beacon.ino
+++ b/beacon/beacon.ino
@@ -110,6 +110,11 @@ void setup()  {
     gps_serial.println(PMTK_API_SET_FIX_CTL_1HZ);   // 1 Hz fix rate
 
     delay(1000);
+    // Stop interrupts from GPS serial input.
+    // All GPS readers have/ to call listen() 
+    // and end with stopListening, or else
+    // interrupts disturb time-critical code sections.
+    gps_serial.stopListening();
   }
 
   FPPRINTRC(1,0,"QRX INIT GPS DO")

--- a/beacon/gps_do.ino
+++ b/beacon/gps_do.ino
@@ -11,12 +11,22 @@ void gps_end_milliclock_discipline() {
   }
 }
 
+/**
+ * Spend some time trying to get a GPS time.  If we fail, wall_ticks will be messed up.
+ * If we succeed, wall_ticks will be right.
+ *
+ * The GPS SoftwareSerial is off unless we're using it, because 
+ * it generates interrupts, and that would disturb out timing.  This
+ * routine enables here and disables it before exit.
+ */
 boolean gps_discipline_clock(long tries) {
   boolean done = false;
   Serial.println(F("*** GPS Discipline clock start"));
   Serial.flush();
-  // Spend some time trying to get a GPS time.  If we fail, wall_ticks will be messed up.
-  // If we succeed, wall_ticks will be right.
+
+  // Enable SoftwareSerial; disable before exit.
+  gps_serial.listen();
+
   while (--tries > 0) {
     // attend to GPS in event loop
     // not necessary all the time, but does need to happen to keep time sync
@@ -49,9 +59,13 @@ boolean gps_discipline_clock(long tries) {
       }
     }
   }
+
+  gps_serial.stopListening();
+
   Serial.print(F("*** GPS Discipline clock done: "));
   Serial.println(done);
   Serial.flush();
+
   return done;
 }
 


### PR DESCRIPTION
Eliminate interrupts generated by gps_serial by calling stopListening() and listen() around its use.  Start off with stopListening().
